### PR TITLE
Added timer

### DIFF
--- a/ATTACK/Assets/Scenes/DemoScene.unity
+++ b/ATTACK/Assets/Scenes/DemoScene.unity
@@ -9683,7 +9683,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 431}
+  m_AnchoredPosition: {x: 0, y: 467.2}
   m_SizeDelta: {x: 160, y: 30}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1378384533

--- a/ATTACK/Assets/Scenes/DemoScene.unity
+++ b/ATTACK/Assets/Scenes/DemoScene.unity
@@ -8634,6 +8634,7 @@ RectTransform:
   m_Children:
   - {fileID: 1520353345}
   - {fileID: 158083204}
+  - {fileID: 1378384532}
   m_Father: {fileID: 0}
   m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -9648,6 +9649,85 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a9c8a5594dbb6c04fb0ba72fac312f1d, type: 3}
+--- !u!1 &1378384531
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1378384532}
+  - component: {fileID: 1378384534}
+  - component: {fileID: 1378384533}
+  m_Layer: 5
+  m_Name: SetupTimer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1378384532
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1378384531}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1153865619}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 431}
+  m_SizeDelta: {x: 160, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1378384533
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1378384531}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 72
+    m_FontStyle: 1
+    m_BestFit: 0
+    m_MinSize: 7
+    m_MaxSize: 72
+    m_Alignment: 1
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 1
+    m_VerticalOverflow: 1
+    m_LineSpacing: 1
+  m_Text: 
+--- !u!222 &1378384534
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1378384531}
+  m_CullTransparentMesh: 1
 --- !u!1001 &1379677748
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/ATTACK/Assets/Scripts/GameManager.cs
+++ b/ATTACK/Assets/Scripts/GameManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using UnityEngine.Assertions;
+using UnityEngine.UI;
 
 public class GameManager : MonoBehaviour
 {
@@ -105,11 +106,27 @@ public class GameManager : MonoBehaviour
         {
             if (seconds - i == startSoundTime)
                 GetComponent<AudioSource>().Play();
+            updateUITimer(seconds - i);
             yield return new WaitForSeconds(1f);
         }
+        GameObject.Find("SetupTimer").SetActive(false);
         inCombatPhase = true;
         SpawnFromCards();
         CameraHandler.instance.StartCombatCamera();
+    }
+
+    private void updateUITimer(int secondsLeft)
+    {
+        GameObject.Find("SetupTimer").GetComponent<Text>().text = ""+secondsLeft;
+        if(secondsLeft < 4)
+        {
+            if(secondsLeft == 1)
+                GameObject.Find("SetupTimer").GetComponent<Text>().color = Color.red;
+            else
+                GameObject.Find("SetupTimer").GetComponent<Text>().color = Color.yellow;
+            GameObject.Find("SetupTimer").GetComponent<Text>().fontSize += 16;
+        } 
+        
     }
 
     public Vector3 GetRandomTarget(Team characterTeam)

--- a/ATTACK/Assets/Scripts/GameManager.cs
+++ b/ATTACK/Assets/Scripts/GameManager.cs
@@ -117,14 +117,15 @@ public class GameManager : MonoBehaviour
 
     private void updateUITimer(int secondsLeft)
     {
-        GameObject.Find("SetupTimer").GetComponent<Text>().text = ""+secondsLeft;
+        Text setupTimerText = GameObject.Find("SetupTimer").GetComponent<Text>();
+        setupTimerText.text = ""+secondsLeft;
         if(secondsLeft < 4)
         {
             if(secondsLeft == 1)
-                GameObject.Find("SetupTimer").GetComponent<Text>().color = Color.red;
+                setupTimerText.color = Color.red;
             else
-                GameObject.Find("SetupTimer").GetComponent<Text>().color = Color.yellow;
-            GameObject.Find("SetupTimer").GetComponent<Text>().fontSize += 16;
+                setupTimerText.color = Color.yellow;
+            setupTimerText.fontSize += 16;
         } 
         
     }


### PR DESCRIPTION
It should display at the beginning of the Setup Phase, and follow the countdown.

Once the lower seconds are left (and sounds play for each), the color should change to yellow and finally red, while the size increases each time.

Once the Battle Phase starts, it is set to be unactive, and disappears. Currently, there's no consideration for any reset, but can easily be added later.